### PR TITLE
Fixed Minor Indentation Bug

### DIFF
--- a/loubia.py
+++ b/loubia.py
@@ -114,7 +114,7 @@ def update_payload():
 	# if shell is bash replace "/bin/sh" with "/bin/bash"
 	elif shell == 'bash':
 		packet = packet.replace( '72f62696e2f7368', '92f62696e2f62617368' )
-	if verbose: print '[INFO] Target os is unix: using "/bin/'+shell+' -c"\n'
+		if verbose: print '[INFO] Target os is unix: using "/bin/'+shell+' -c"\n'
 
 # t3 packet must be preceeded by the total length of the packet (bytes) represented in hexa
 def update_length():


### PR DESCRIPTION
When targeting a Windows machine with verbose output on, the script would write that it was using a Windows target, and then repeat the message for a Linux target.

E.g.
```
[INFO] Target os is win: using "cmd.exe /c"
[INFO] Target os is unix: using "/bin/sh -c"
```

This was due to a line that should have been indented.